### PR TITLE
Add trust policy conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ No resources.
 | <a name="input_role_sts_externalid"></a> [role\_sts\_externalid](#input\_role\_sts\_externalid) | STS ExternalId condition values to use with this role. | `list(string)` | `[]` | no |
 | <a name="input_trusted_role_arns"></a> [trusted\_role\_arns](#input\_trusted\_role\_arns) | ARNs of AWS entities who can assume this role. | `list(string)` | `[]` | no |
 | <a name="input_trusted_role_services"></a> [trusted\_role\_services](#input\_trusted\_role\_services) | Names of AWS Services that can assume this role. | `list(string)` | `[]` | no |
+| <a name="input_trust_policy_conditions"></a> [trust\_policy\_conditions](#input\_trust\_policy\_conditions) | Condition constraints applied to the trust policy. | <pre>list(object({<br>    test     = string<br>    variable = string<br>    values   = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_allow_self_assume_role"></a> [allow\_self\_assume\_role](#input\_allow\_self\_assume\_role) | Determines whether to allow the role to be assume itself. | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources created by the module. | `map(string)` | `{}` | no |
 

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,7 @@ module "iam_role" {
 
   trusted_role_arns       = var.trusted_role_arns
   trusted_role_services   = var.trusted_role_services
+  trust_policy_conditions = var.trust_policy_conditions
   role_sts_externalid     = var.role_sts_externalid
   custom_role_policy_arns = module.iam_policies[*].arn
 

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,16 @@ variable "trusted_role_services" {
   default     = []
 }
 
+variable "trust_policy_conditions" {
+  description = "Condition constraints applied to the trust policy."
+  type = list(object({
+    test     = string
+    variable = string
+    values   = list(string)
+  }))
+  default = []
+}
+
 variable "allow_self_assume_role" {
   description = "Determines whether to allow the role to be assume itself."
   type        = bool


### PR DESCRIPTION
Adds [Trust Policy Conditions](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html) to prevent the confused deputy problem in AWS EventBridge Scheduler.